### PR TITLE
Update Chapter_26_Instructions.md

### DIFF
--- a/Chapter-Instructions/Chapter_26_Instructions.md
+++ b/Chapter-Instructions/Chapter_26_Instructions.md
@@ -155,7 +155,7 @@ an error:
 ``` r
 df |> 
   group_by(grp) |> 
-  summarize(across(everything(), median()))
+  summarize(across(everything(), median))
 ```
 
 ------------------------------------------------------------------------


### PR DESCRIPTION
removed a "()" after median that was bringing back an error

Error:
<img width="308" height="337" alt="Screenshot 2025-09-20 at 2 35 34 PM" src="https://github.com/user-attachments/assets/1aa59962-1d5a-4e80-b52e-ceeca35955be" />

Fix:
<img width="298" height="294" alt="Screenshot 2025-09-20 at 2 35 55 PM" src="https://github.com/user-attachments/assets/3d3ec69b-f528-4140-9ab6-a9827448e788" />
