### PR TITLE
Update Chapter_26_Instructions.qmd

### DIFF
--- a/Chapter-Instructions/Chapter_26_Instructions.qmd
+++ b/Chapter-Instructions/Chapter_26_Instructions.qmd
@@ -122,7 +122,7 @@ If you forget, you’ll get an error:
 #| eval: false
 df |> 
   group_by(grp) |> 
-  summarize(across(everything(), median()))
+  summarize(across(everything(), median))
 ```
 
 ------------------------------------------------------------------------


### PR DESCRIPTION
removed a "()" after median that was bringing back an error

Error:
<img width="616" height="674" alt="image" src="https://github.com/user-attachments/assets/744a313c-e82d-4e46-9a95-d2b237ffba72" />

Fix:
<img width="596" height="588" alt="image" src="https://github.com/user-attachments/assets/64281541-8f7b-4a3d-b497-a44f140300ad" />
